### PR TITLE
Add celsiusToTempCode alias

### DIFF
--- a/__tests__/util.spec.ts
+++ b/__tests__/util.spec.ts
@@ -1,4 +1,4 @@
-import { tempCodeToCelsius, celciusToTempCode, parseDate, addMinutes } from '../src/util';
+import { tempCodeToCelsius, celciusToTempCode, celsiusToTempCode, parseDate, addMinutes } from '../src/util';
 import { REGIONS } from '../src/constants';
 
 describe('Utility', () => {
@@ -12,10 +12,19 @@ describe('Utility', () => {
   
   it('converts celsius to temp code in CA', () => {
     expect(celciusToTempCode(REGIONS.CA, 18)).toEqual('04H');
+    expect(celsiusToTempCode(REGIONS.CA, 18)).toEqual('04H');
+
     expect(celciusToTempCode(REGIONS.CA, 21.5)).toEqual('0BH');
+    expect(celsiusToTempCode(REGIONS.CA, 21.5)).toEqual('0BH');
+
     expect(celciusToTempCode(REGIONS.CA, 24)).toEqual('10H');
+    expect(celsiusToTempCode(REGIONS.CA, 24)).toEqual('10H');
+
     expect(celciusToTempCode(REGIONS.CA, 28)).toEqual('18H');
+    expect(celsiusToTempCode(REGIONS.CA, 28)).toEqual('18H');
+
     expect(celciusToTempCode(REGIONS.CA, 32)).toEqual('20H');
+    expect(celsiusToTempCode(REGIONS.CA, 32)).toEqual('20H');
   });
 
   it('converts temp code to celsius in EU', () => {
@@ -26,8 +35,13 @@ describe('Utility', () => {
 
   it('converts celcius to temp code in EU', () => {
     expect(celciusToTempCode(REGIONS.EU, 17)).toEqual('06H');
+    expect(celsiusToTempCode(REGIONS.EU, 17)).toEqual('06H');
+
     expect(celciusToTempCode(REGIONS.EU, 20)).toEqual('0CH');
+    expect(celsiusToTempCode(REGIONS.EU, 20)).toEqual('0CH');
+
     expect(celciusToTempCode(REGIONS.EU, 27)).toEqual('1AH');
+    expect(celsiusToTempCode(REGIONS.EU, 27)).toEqual('1AH');
   });
 
   it('parseDate converts string to date', () => {

--- a/src/util.ts
+++ b/src/util.ts
@@ -37,6 +37,12 @@ const REGION_STEP_RANGES = {
 // Converts Kia's stupid temp codes to celsius
 // From what I can tell it uses a hex index on a list of temperatures starting at 14c ending at 30c with an added H on the end,
 // I'm thinking it has to do with Heat/Cool H/C but needs to be tested, while the car is off, it defaults to 01H
+/**
+ * Converts a Celsius temperature to the protocol specific temp code.
+ *
+ * @deprecated Use {@link celsiusToTempCode} instead. This function is kept
+ *             for backwards compatibility.
+ */
 export const celciusToTempCode = (region: REGION, temperature: number): string => {
   // create a range of floats
   const { start, end, step } = REGION_STEP_RANGES[region];
@@ -52,6 +58,10 @@ export const celciusToTempCode = (region: REGION, temperature: number): string =
   // this needs more testing I guess :P
   return `${hexCode.split('x')[1].toUpperCase()}H`.padStart(3, '0');
 };
+
+// Provide a correctly spelled helper for new code while keeping the old
+// misspelled version for backwards compatibility.
+export const celsiusToTempCode = celciusToTempCode;
 
 export const tempCodeToCelsius = (region: REGION, code: string): number => {
   // create a range


### PR DESCRIPTION
## Summary
- add `celsiusToTempCode` alias and mark the old misspelled function deprecated
- verify old and new helpers behave the same in tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688bbf32fc6c8332a161c42ec2815445